### PR TITLE
Improve sidebar UX for equation and graph editing

### DIFF
--- a/packages/core/src/ui/EquationPanel.tsx
+++ b/packages/core/src/ui/EquationPanel.tsx
@@ -128,10 +128,10 @@ export function EquationPanel({
   const t = useMemo(() => getTheme(isDark), [isDark]);
 
   useEffect(() => {
-    if (editingLatex !== undefined && editingLatex !== null) {
-      setLatex(editingLatex);
-      setShowLibrary(false);
-    }
+    if (editingLatex === undefined) return;
+
+    setLatex(editingLatex ?? "");
+    setShowLibrary(false);
   }, [editingLatex]);
 
   const validationError = useMemo(() => {
@@ -193,6 +193,10 @@ export function EquationPanel({
     if (!latex.trim() || validationError) return;
     const result = renderLatexToSvg(latex);
     onInsert(latex, result.svg, result.width, result.height);
+    // Restore focus after insert or update
+    setTimeout(() => {
+      textareaRef.current?.focus();
+    }, 50);
   }, [latex, validationError, onInsert]);
 
   const handleExpressionClick = useCallback((entry: ExpressionEntry) => {
@@ -346,6 +350,7 @@ export function EquationPanel({
             placeholder={'Type LaTeX or use the toolbar above'}
             style={{
               width: "100%", padding: "9px 11px", border: `1px solid ${t.border}`,
+              boxSizing: "border-box", minWidth: 0,
               borderRadius: 6, fontFamily: '"Fira Code", "Cascadia Code", monospace',
               fontSize: 13, resize: "vertical", outline: "none", lineHeight: 1.5,
               backgroundColor: t.bgInput, color: t.text,

--- a/packages/core/src/ui/ExcaliMath.tsx
+++ b/packages/core/src/ui/ExcaliMath.tsx
@@ -64,6 +64,7 @@ export function ExcaliMath({
   const [editingLatex, setEditingLatex] = useState<string | null>(null);
   const [editingGraphConfig, setEditingGraphConfig] = useState<GraphConfig | null>(null);
   const editingElementIdRef = useRef<string | null>(null);
+  const lastPolledSelectionRef = useRef<string | null>(null);
   const restoredRef = useRef(false);
 
   // ── Theme resolution ──
@@ -168,9 +169,64 @@ export function ExcaliMath({
     return getSelectedExcalimathElement(selected);
   }, [excalidrawAPI]);
 
+  // ── Auto-update on canvas selection ──
+  // When the sidebar is open and user selects an equation/graph on canvas,
+  // automatically switch to edit mode for that element.
+  // When deselecting an element, drop back to insert mode.
+  useEffect(() => {
+    if (!excalidrawAPI || activeTab === null) return;
+
+    const checkSelection = () => {
+      const appState = excalidrawAPI.getAppState();
+      const selectedIds = appState.selectedElementIds || {};
+      const activeIds = Object.keys(selectedIds).filter((id) => selectedIds[id]);
+      const currentSelectedId = activeIds.length === 1 ? activeIds[0] : null;
+
+      // Only act if the canvas selection has distinctly changed
+      if (currentSelectedId === lastPolledSelectionRef.current) {
+        return;
+      }
+
+      lastPolledSelectionRef.current = currentSelectedId;
+      const selected = getSelectedElement();
+
+      if (!selected) {
+        // User deselected or selected a non-ExcaliMath element -> Insert mode
+        if (editingElementIdRef.current !== null) {
+          setEditingLatex(null);
+          setEditingGraphConfig(null);
+          editingElementIdRef.current = null;
+        }
+        return;
+      }
+
+      // User selected an ExcaliMath element -> Edit mode
+      if (selected.type === "equation") {
+        setEditingLatex(selected.data.latex);
+        editingElementIdRef.current = selected.data.elementId;
+        setActiveTab("equation");
+      } else if (selected.type === "graph") {
+        try {
+          setEditingGraphConfig(JSON.parse(selected.data.config));
+          editingElementIdRef.current = selected.data.elementId;
+          setActiveTab("graph");
+        } catch { /* ignore */ }
+      }
+    };
+
+    // Check immediately in case selection changed before sidebar opened
+    checkSelection();
+
+    // Poll for selection changes while sidebar is open
+    const interval = setInterval(checkSelection, 100);
+    return () => clearInterval(interval);
+  }, [excalidrawAPI, activeTab, getSelectedElement]);
+
   const upsertElement = useCallback(
     (svg: string, width: number, height: number, metadata: ExcalimathMetadata) => {
-      if (!excalidrawAPI) return;
+      if (!excalidrawAPI) return undefined;
+
+      const appState = excalidrawAPI.getAppState();
 
       if (editingElementIdRef.current) {
         const elements = excalidrawAPI.getSceneElements();
@@ -191,9 +247,16 @@ export function ExcaliMath({
             ? { ...element, id: el.id }
             : el
         );
-        excalidrawAPI.updateScene({ elements: updatedElements });
+        excalidrawAPI.updateScene({
+          elements: updatedElements,
+          appState: {
+            ...appState,
+            selectedElementIds: { [editingElementIdRef.current]: true }
+          }
+        });
+        emitSave();
+        return editingElementIdRef.current;
       } else {
-        const appState = excalidrawAPI.getAppState();
         const centerX =
           (appState.scrollX * -1 + appState.width / 2) / appState.zoom.value -
           width / 2;
@@ -210,11 +273,14 @@ export function ExcaliMath({
         const currentElements = excalidrawAPI.getSceneElements();
         excalidrawAPI.updateScene({
           elements: [...currentElements, element],
+          appState: {
+            ...appState,
+            selectedElementIds: { [element.id]: true }
+          }
         });
+        emitSave();
+        return element.id;
       }
-
-      editingElementIdRef.current = null;
-      emitSave();
     },
     [excalidrawAPI, emitSave]
   );
@@ -273,24 +339,30 @@ export function ExcaliMath({
 
   const handleInsertEquation = useCallback(
     (latex: string, svg: string, width: number, height: number) => {
-      upsertElement(svg, width, height, {
+      const newId = upsertElement(svg, width, height, {
         excalimath_type: "equation",
         excalimath_source: "equation-panel",
         excalimath_latex: latex,
       });
-      setEditingLatex(null);
+      if (newId) {
+        editingElementIdRef.current = newId;
+        setEditingLatex(latex);
+      }
     },
     [upsertElement]
   );
 
   const handleInsertGraph = useCallback(
     (config: GraphConfig, svg: string, width: number, height: number) => {
-      upsertElement(svg, width, height, {
+      const newId = upsertElement(svg, width, height, {
         excalimath_type: "graph",
         excalimath_source: "graph-panel",
         excalimath_graph_config: JSON.stringify(config),
       });
-      setEditingGraphConfig(null);
+      if (newId) {
+        editingElementIdRef.current = newId;
+        setEditingGraphConfig(config);
+      }
     },
     [upsertElement]
   );
@@ -458,6 +530,22 @@ export function ExcaliMath({
             id={`excalimath-panel-${activeTab}`}
             style={{ flex: 1, overflow: "hidden", display: "flex", flexDirection: "column" }}
           >
+            <style>
+              {`
+                /* Hide KaTeX MathML so it doesn't show double text */
+                .katex-mathml {
+                  display: none;
+                }
+
+                @media (max-width: 730px) {
+                  /* Push ExcaliMath container content up so it's not hidden by bottom bars */
+                  #excalimath-panel-${activeTab} {
+                    padding-bottom: 60px !important;
+                  }
+                }
+              `}
+            </style>
+            
             {activeTab === "equation" && equationEnabled && (
               <EquationPanel
                 visible={true}

--- a/packages/core/src/ui/GraphPanel.tsx
+++ b/packages/core/src/ui/GraphPanel.tsx
@@ -52,6 +52,8 @@ export function GraphPanel({
     if (editingConfig) {
       setConfig(editingConfig);
       setActiveTab("functions");
+    } else {
+      setConfig(createDefaultGraphConfig());
     }
   }, [editingConfig]);
 
@@ -191,7 +193,8 @@ export function GraphPanel({
 
   const inputStyle: React.CSSProperties = {
     padding: "7px 10px", border: `1px solid ${t.border}`, borderRadius: 5,
-    fontSize: 12, outline: "none", backgroundColor: t.bgInput, color: t.text, width: "100%",
+    fontSize: 12, outline: "none", backgroundColor: t.bgInput, color: t.text,
+    width: "100%", boxSizing: "border-box", minWidth: 0,
   };
 
   const labelStyle: React.CSSProperties = {
@@ -386,14 +389,15 @@ export function GraphPanel({
 
         {/* Preview */}
         {previewSvg && (
-          <div style={{ display: "flex", flexDirection: "column", gap: 6, marginTop: 6 }}>
+          <div style={{ display: "flex", flexDirection: "column", gap: 6, marginTop: 6, width: "100%" }}>
             <label style={labelStyle}>Preview</label>
             <div
               ref={previewRef}
               style={{
                 backgroundColor: t.bgElevated, borderRadius: 6,
-                border: `1px solid ${t.borderLight}`, overflow: "hidden",
-                display: "flex", justifyContent: "center",
+                border: `1px solid ${t.borderLight}`, overflowX: "auto", overflowY: "hidden",
+                display: "block",
+                padding: "8px", minHeight: 150
               }}
               dangerouslySetInnerHTML={{ __html: previewSvg }}
             />


### PR DESCRIPTION
## Summary
This PR improves the ExcaliMath sidebar workflow for equation and graph editing, fixes panel/input overflow issues, and improves mobile behavior so panel actions remain usable.

## Changes
1. Selection-aware edit mode in packages/core/src/ui/ExcaliMath.tsx
- Keeps sidebar state synced with selected ExcaliMath element on canvas.
- Switches to edit mode when selecting equation/graph elements.
- Returns to insert mode when deselecting or selecting non-ExcaliMath elements.
- Preserves selection on insert/update to keep editing context stable.
2. Equation editor UX fixes in packages/core/src/ui/EquationPanel.tsx
- Keeps textarea focused after insert/update.
- Fixes textarea overflow on narrow widths using border-box sizing.
3. Graph editor UX fixes in packages/core/src/ui/GraphPanel.tsx
- Resets to default insert config when edit selection is cleared.
- Enables horizontal scrolling for wide graph previews.
- Fixes input and CSV textarea overflow with border-box sizing.
4. Sidebar CSS adjustments in packages/core/src/ui/ExcaliMath.tsx
- Hides duplicate KaTeX fallback layer to avoid double-rendered text.
- Adds mobile bottom padding in the panel to prevent action overlap with bottom UI.

## Type of change
- [x] Bug fix
- [x] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation update
- [ ] New shape library / shapes

## Checklist
- [x] `npm run build` passes
- [x] Code follows existing style conventions
- [x] Exported functions/interfaces have JSDoc comments
- [x] Self-reviewed the diff
