### PR TITLE
Improve sidebar editing UX and reduce SVG whitespace (equation + graph)

### DIFF
--- a/packages/core/src/plugins/equation/renderer.ts
+++ b/packages/core/src/plugins/equation/renderer.ts
@@ -62,8 +62,8 @@ export function renderLatexToSvg(
 
   // Measure actual rendered dimensions from the DOM
   const measured = measureMathml(mathml, fontSize);
-  const padding = 20;
-  const svgWidth = Math.max(measured.width + padding * 2, 60);
+  const padding = 2; // Margins of svg
+  const svgWidth = Math.max(measured.width + padding * 2, 20);
   const svgHeight = Math.max(measured.height + padding * 2, 40);
 
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${svgWidth}" height="${svgHeight}">

--- a/packages/core/src/plugins/graph/plotRenderer.ts
+++ b/packages/core/src/plugins/graph/plotRenderer.ts
@@ -81,7 +81,7 @@ export async function renderGraphToSvg(
       zerolinecolor: "#444",
       dtick: axis.tickInterval,
     },
-    margin: { l: 50, r: 30, t: 20, b: 50 },
+    margin: { l: 30, r: 20, t: 20, b: 30 }, // Margins of svg
     paper_bgcolor: config.backgroundColor === "transparent" ? "rgba(0,0,0,0)" : config.backgroundColor,
     plot_bgcolor: config.backgroundColor === "transparent" ? "rgba(0,0,0,0)" : config.backgroundColor,
     showlegend: traces.length > 1,

--- a/packages/core/src/ui/EquationPanel.tsx
+++ b/packages/core/src/ui/EquationPanel.tsx
@@ -351,6 +351,7 @@ export function EquationPanel({
             style={{
               width: "100%", padding: "9px 11px", border: `1px solid ${t.border}`,
               boxSizing: "border-box", minWidth: 0,
+              minHeight: 40,
               borderRadius: 6, fontFamily: '"Fira Code", "Cascadia Code", monospace',
               fontSize: 13, resize: "vertical", outline: "none", lineHeight: 1.5,
               backgroundColor: t.bgInput, color: t.text,

--- a/packages/core/src/ui/EquationPanel.tsx
+++ b/packages/core/src/ui/EquationPanel.tsx
@@ -124,7 +124,9 @@ export function EquationPanel({
   const [showLibrary, setShowLibrary] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState("");
   const [searchTerm, setSearchTerm] = useState("");
+  const [isPreviewOverflowing, setIsPreviewOverflowing] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const previewRef = useRef<HTMLDivElement>(null);
   const t = useMemo(() => getTheme(isDark), [isDark]);
 
   useEffect(() => {
@@ -139,7 +141,7 @@ export function EquationPanel({
     return validateLatex(latex);
   }, [latex]);
 
-  const previewHtml = useMemo(() => {
+  const rawPreviewHtml = useMemo(() => {
     if (!latex.trim() || validationError) return "";
     try {
       return katex.renderToString(latex, { displayMode: true, throwOnError: false });
@@ -147,6 +149,36 @@ export function EquationPanel({
       return "";
     }
   }, [latex, validationError]);
+
+  const previewHtml = useMemo(() => {
+    if (!rawPreviewHtml) return "";
+    if (!isPreviewOverflowing) return rawPreviewHtml;
+    return rawPreviewHtml.replace(
+      'class="katex-display"',
+      'class="katex-display" style="text-align:left;margin:0"'
+    );
+  }, [rawPreviewHtml, isPreviewOverflowing]);
+
+  useEffect(() => {
+    if (!rawPreviewHtml || validationError) {
+      setIsPreviewOverflowing(false);
+      return;
+    }
+
+    const checkOverflow = () => {
+      const el = previewRef.current;
+      if (!el) return;
+      const overflowing = el.scrollWidth > el.clientWidth + 1;
+      setIsPreviewOverflowing((prev) => (prev === overflowing ? prev : overflowing));
+    };
+
+    const rafId = requestAnimationFrame(checkOverflow);
+    window.addEventListener("resize", checkOverflow);
+    return () => {
+      cancelAnimationFrame(rafId);
+      window.removeEventListener("resize", checkOverflow);
+    };
+  }, [rawPreviewHtml, validationError]);
 
   const categories = useMemo(() => getCategories(), []);
   const filteredExpressions = useMemo(
@@ -376,10 +408,14 @@ export function EquationPanel({
                 Preview
               </label>
               <div
+                ref={previewRef}
                 style={{
                   padding: "16px", backgroundColor: t.bgElevated, borderRadius: 6,
-                  textAlign: "center", minHeight: 50, display: "flex",
-                  alignItems: "center", justifyContent: "center",
+                  textAlign: isPreviewOverflowing ? "left" : "center",
+                  minHeight: 50, maxHeight: 220, overflowY: "auto",
+                  overflowX: "auto", display: "flex",
+                  alignItems: "center",
+                  justifyContent: isPreviewOverflowing ? "flex-start" : "center",
                   border: `1px solid ${t.borderLight}`, color: t.text,
                 }}
                 dangerouslySetInnerHTML={{ __html: previewHtml }}

--- a/packages/core/src/ui/EquationPanel.tsx
+++ b/packages/core/src/ui/EquationPanel.tsx
@@ -173,12 +173,18 @@ export function EquationPanel({
     };
 
     const rafId = requestAnimationFrame(checkOverflow);
+    let resizeObserver: ResizeObserver | null = null;
+    if (typeof ResizeObserver !== "undefined" && previewRef.current) {
+      resizeObserver = new ResizeObserver(checkOverflow);
+      resizeObserver.observe(previewRef.current);
+    }
     window.addEventListener("resize", checkOverflow);
     return () => {
       cancelAnimationFrame(rafId);
+      resizeObserver?.disconnect();
       window.removeEventListener("resize", checkOverflow);
     };
-  }, [rawPreviewHtml, validationError]);
+  }, [rawPreviewHtml, validationError, isPreviewOverflowing]);
 
   const categories = useMemo(() => getCategories(), []);
   const filteredExpressions = useMemo(

--- a/packages/core/src/ui/ExcaliMath.tsx
+++ b/packages/core/src/ui/ExcaliMath.tsx
@@ -66,6 +66,19 @@ export function ExcaliMath({
   const editingElementIdRef = useRef<string | null>(null);
   const lastPolledSelectionRef = useRef<string | null>(null);
   const restoredRef = useRef(false);
+  const isVsCodeWebview = useMemo(() => {
+    if (typeof window === "undefined" || typeof document === "undefined") return false;
+    const body = document.body;
+    if (!body) return false;
+    if (
+      body.classList.contains("vscode-light") ||
+      body.classList.contains("vscode-dark") ||
+      body.classList.contains("vscode-high-contrast")
+    ) {
+      return true;
+    }
+    return typeof (window as any).acquireVsCodeApi === "function";
+  }, []);
 
   // ── Theme resolution ──
   const excalidrawTheme = excalidrawAPI?.getAppState?.()?.theme;
@@ -173,54 +186,66 @@ export function ExcaliMath({
   // When the sidebar is open and user selects an equation/graph on canvas,
   // automatically switch to edit mode for that element.
   // When deselecting an element, drop back to insert mode.
+  const syncSelectionFromCanvas = useCallback(() => {
+    if (!excalidrawAPI) return;
+
+    const appState = excalidrawAPI.getAppState();
+    const selectedIds = appState.selectedElementIds || {};
+    const activeIds = Object.keys(selectedIds).filter((id) => selectedIds[id]);
+    const currentSelectedId = activeIds.length === 1 ? activeIds[0] : null;
+
+    // Only act if the canvas selection has distinctly changed
+    if (currentSelectedId === lastPolledSelectionRef.current) {
+      return;
+    }
+
+    lastPolledSelectionRef.current = currentSelectedId;
+    const selected = getSelectedElement();
+
+    if (!selected) {
+      // User deselected or selected a non-ExcaliMath element -> Insert mode
+      if (editingElementIdRef.current !== null) {
+        setEditingLatex(null);
+        setEditingGraphConfig(null);
+        editingElementIdRef.current = null;
+      }
+      return;
+    }
+
+    // User selected an ExcaliMath element -> Edit mode
+    if (selected.type === "equation") {
+      setEditingLatex(selected.data.latex);
+      editingElementIdRef.current = selected.data.elementId;
+      setActiveTab("equation");
+    } else if (selected.type === "graph") {
+      try {
+        setEditingGraphConfig(JSON.parse(selected.data.config));
+        editingElementIdRef.current = selected.data.elementId;
+        setActiveTab("graph");
+      } catch { /* ignore */ }
+    }
+  }, [excalidrawAPI, getSelectedElement]);
+
   useEffect(() => {
     if (!excalidrawAPI || activeTab === null) return;
 
-    const checkSelection = () => {
-      const appState = excalidrawAPI.getAppState();
-      const selectedIds = appState.selectedElementIds || {};
-      const activeIds = Object.keys(selectedIds).filter((id) => selectedIds[id]);
-      const currentSelectedId = activeIds.length === 1 ? activeIds[0] : null;
-
-      // Only act if the canvas selection has distinctly changed
-      if (currentSelectedId === lastPolledSelectionRef.current) {
-        return;
-      }
-
-      lastPolledSelectionRef.current = currentSelectedId;
-      const selected = getSelectedElement();
-
-      if (!selected) {
-        // User deselected or selected a non-ExcaliMath element -> Insert mode
-        if (editingElementIdRef.current !== null) {
-          setEditingLatex(null);
-          setEditingGraphConfig(null);
-          editingElementIdRef.current = null;
-        }
-        return;
-      }
-
-      // User selected an ExcaliMath element -> Edit mode
-      if (selected.type === "equation") {
-        setEditingLatex(selected.data.latex);
-        editingElementIdRef.current = selected.data.elementId;
-        setActiveTab("equation");
-      } else if (selected.type === "graph") {
-        try {
-          setEditingGraphConfig(JSON.parse(selected.data.config));
-          editingElementIdRef.current = selected.data.elementId;
-          setActiveTab("graph");
-        } catch { /* ignore */ }
-      }
-    };
-
     // Check immediately in case selection changed before sidebar opened
-    checkSelection();
+    syncSelectionFromCanvas();
 
-    // Poll for selection changes while sidebar is open
-    const interval = setInterval(checkSelection, 100);
+    // Prefer API subscription when available for efficient updates.
+    if (typeof excalidrawAPI.onChange === "function") {
+      const unsubscribe = excalidrawAPI.onChange(() => {
+        syncSelectionFromCanvas();
+      });
+      return () => {
+        if (typeof unsubscribe === "function") unsubscribe();
+      };
+    }
+
+    // Fallback for hosts with no onChange API.
+    const interval = setInterval(syncSelectionFromCanvas, 300);
     return () => clearInterval(interval);
-  }, [excalidrawAPI, activeTab, getSelectedElement]);
+  }, [excalidrawAPI, activeTab, syncSelectionFromCanvas]);
 
   const upsertElement = useCallback(
     (svg: string, width: number, height: number, metadata: ExcalimathMetadata) => {
@@ -439,6 +464,7 @@ export function ExcaliMath({
       {/* ── Sidebar ── */}
       {isOpen && (
         <div
+          className="excalimath-sidebar"
           role="dialog"
           aria-label="ExcaliMath"
           style={{
@@ -532,10 +558,12 @@ export function ExcaliMath({
           >
             <style>
               {`
-                /* Hide KaTeX MathML so it doesn't show double text */
-                .katex-mathml {
-                  display: none;
-                }
+                ${isVsCodeWebview ? `
+                  /* VS Code webview workaround: prevent duplicate visible KaTeX text */
+                  .excalimath-sidebar .katex-html {
+                    display: none;
+                  }
+                ` : ""}
 
                 @media (max-width: 730px) {
                   /* Push ExcaliMath container content up so it's not hidden by bottom bars */


### PR DESCRIPTION
## Summary
This PR improves the equation/graph editing flow in the sidebar and tightens whitespace around generated SVGs.

## Changes
1. Improved equation preview behavior:
- Preview becomes scrollable when content is large.
- Alignment is centered by default and switches left only when horizontal overflow is detected.
- Added resize-aware overflow detection for more accurate real-time behavior.
2. Improved sidebar editing UX:
- Better selection sync between canvas and sidebar edit mode.
- Uses API-driven change subscription when available, with a lighter fallback interval.
- Keeps behavior responsive while reducing unnecessary polling overhead.
3. Added VS Code webview-specific KaTeX visibility workaround:
- Applies only in VS Code/webview context to avoid affecting browser behavior.
- Reduced generated SVG border/whitespace:
4. Equation SVG padding reduced.
- Graph Plotly margins reduced.

## Type of change
- [x] Bug fix
- [x] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation update
- [ ] New shape library / shapes

## Checklist
- [x] `npm run build` passes
- [x] Code follows existing style conventions
- [x] Exported functions/interfaces have JSDoc comments
- [x] Self-reviewed the diff
