### PR TITLE
Improve graph dark theme visibility

### DIFF
--- a/packages/core/src/plugins/graph/plotRenderer.ts
+++ b/packages/core/src/plugins/graph/plotRenderer.ts
@@ -10,14 +10,94 @@ import Plotly from "plotly.js-dist-min";
 import { evaluateFunction } from "./evaluator";
 import type { GraphConfig } from "./types";
 
+type RenderPurpose = "preview" | "insert";
+
+interface RenderOptions {
+  isDark?: boolean;
+  purpose?: RenderPurpose;
+}
+
+function parseHexColor(input: string): { r: number; g: number; b: number } | null {
+  const value = input.trim().toLowerCase();
+  if (!value.startsWith("#")) return null;
+
+  const hex = value.slice(1);
+  if (hex.length === 3) {
+    const r = parseInt(hex[0] + hex[0], 16);
+    const g = parseInt(hex[1] + hex[1], 16);
+    const b = parseInt(hex[2] + hex[2], 16);
+    return { r, g, b };
+  }
+
+  if (hex.length === 6) {
+    const r = parseInt(hex.slice(0, 2), 16);
+    const g = parseInt(hex.slice(2, 4), 16);
+    const b = parseInt(hex.slice(4, 6), 16);
+    return { r, g, b };
+  }
+
+  return null;
+}
+
+function isDarkHexColor(hex: string): boolean {
+  const rgb = parseHexColor(hex);
+  if (!rgb) return false;
+  const luminance = (0.299 * rgb.r + 0.587 * rgb.g + 0.114 * rgb.b) / 255;
+  return luminance < 0.5;
+}
+
+function toHex(n: number): string {
+  return Math.max(0, Math.min(255, Math.round(n)))
+    .toString(16)
+    .padStart(2, "0");
+}
+
+function brightenHex(hex: string, amount = 0.45): string {
+  const rgb = parseHexColor(hex);
+  if (!rgb) return hex;
+  const r = rgb.r + (255 - rgb.r) * amount;
+  const g = rgb.g + (255 - rgb.g) * amount;
+  const b = rgb.b + (255 - rgb.b) * amount;
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function getVisibleTraceColor(color: string, isDarkBackground: boolean): string {
+  if (!isDarkBackground) return color;
+  if (!color.startsWith("#")) return color;
+  return isDarkHexColor(color) ? brightenHex(color, 0.5) : color;
+}
+
+function getPalette(config: GraphConfig, options: RenderOptions) {
+  const isTransparentBg = config.backgroundColor === "transparent";
+  const useDarkPaletteForTransparent =
+    isTransparentBg && options.purpose === "preview" && !!options.isDark;
+  const isDarkBackground =
+    useDarkPaletteForTransparent ||
+    (!isTransparentBg && isDarkHexColor(config.backgroundColor));
+
+  return {
+    isTransparentBg,
+    isDarkBackground,
+    axisColor: isDarkBackground ? "#e5e7eb" : "#1f2937",
+    gridColor: isDarkBackground
+      ? "rgba(229,231,235,0.28)"
+      : "rgba(31,41,55,0.18)",
+  };
+}
+
 /**
  * Render a graph config to an SVG string using Plotly.js.
  * Uses an off-screen div — returns the raw SVG markup.
  */
 export async function renderGraphToSvg(
-  config: GraphConfig
+  config: GraphConfig,
+  options: RenderOptions = {}
 ): Promise<{ svg: string; width: number; height: number }> {
   const { functions, dataTraces, axis, width, height } = config;
+  const { isTransparentBg, isDarkBackground, axisColor, gridColor } = getPalette(
+    config,
+    options
+  );
 
   // Build Plotly traces from function expressions
   const traces: Plotly.Data[] = [];
@@ -30,13 +110,14 @@ export async function renderGraphToSvg(
         axis.xMin,
         axis.xMax
       );
+      const visibleColor = getVisibleTraceColor(fn.color, isDarkBackground);
       traces.push({
         x,
         y,
         type: "scatter",
         mode: "lines",
         name: fn.label || fn.expression,
-        line: { color: fn.color, width: 2.5 },
+        line: { color: visibleColor, width: 2.5 },
       });
     } catch {
       // Skip invalid functions
@@ -45,14 +126,15 @@ export async function renderGraphToSvg(
 
   // Build Plotly traces from data traces
   for (const dt of dataTraces) {
+    const visibleColor = getVisibleTraceColor(dt.color, isDarkBackground);
     traces.push({
       x: dt.xValues,
       y: dt.yValues,
       type: "scatter",
       mode: dt.mode === "scatter" ? "markers" : "lines",
       name: dt.label || "Data",
-      marker: { color: dt.color, size: 6 },
-      line: { color: dt.color, width: 2 },
+      marker: { color: visibleColor, size: 6 },
+      line: { color: visibleColor, width: 2 },
     });
   }
 
@@ -67,26 +149,30 @@ export async function renderGraphToSvg(
       range: [axis.xMin, axis.xMax],
       title: { text: axis.xLabel },
       showgrid: axis.showGrid,
+      color: axisColor,
+      gridcolor: gridColor,
       zeroline: true,
       zerolinewidth: 1.5,
-      zerolinecolor: "#444",
+      zerolinecolor: axisColor,
       dtick: axis.tickInterval,
     },
     yaxis: {
       range: [axis.yMin, axis.yMax],
       title: { text: axis.yLabel },
       showgrid: axis.showGrid,
+      color: axisColor,
+      gridcolor: gridColor,
       zeroline: true,
       zerolinewidth: 1.5,
-      zerolinecolor: "#444",
+      zerolinecolor: axisColor,
       dtick: axis.tickInterval,
     },
     margin: { l: 30, r: 20, t: 20, b: 30 }, // Margins of svg
-    paper_bgcolor: config.backgroundColor === "transparent" ? "rgba(0,0,0,0)" : config.backgroundColor,
-    plot_bgcolor: config.backgroundColor === "transparent" ? "rgba(0,0,0,0)" : config.backgroundColor,
+    paper_bgcolor: isTransparentBg ? "rgba(0,0,0,0)" : config.backgroundColor,
+    plot_bgcolor: isTransparentBg ? "rgba(0,0,0,0)" : config.backgroundColor,
     showlegend: traces.length > 1,
-    legend: { x: 0.02, y: 0.98 },
-    font: { family: "Arial, sans-serif", size: 12 },
+    legend: { x: 0.02, y: 0.98, font: { color: axisColor } },
+    font: { family: "Arial, sans-serif", size: 12, color: axisColor },
   };
 
   // Render into off-screen container
@@ -109,7 +195,7 @@ export async function renderGraphToSvg(
     }
 
     // Strip background rects when transparent mode is active
-    if (config.backgroundColor === "transparent") {
+    if (isTransparentBg) {
       svgElement.querySelectorAll("rect.bg").forEach((el) => el.remove());
       const mainBg = svgElement.querySelector(".main-svg > rect");
       if (mainBg) mainBg.setAttribute("fill", "none");

--- a/packages/core/src/plugins/graph/plotRenderer.ts
+++ b/packages/core/src/plugins/graph/plotRenderer.ts
@@ -98,6 +98,19 @@ export async function renderGraphToSvg(
     config,
     options
   );
+  const resolveVisibleTraceColor = (() => {
+    if (!isDarkBackground) return (color: string) => color;
+
+    const colorCache = new Map<string, string>();
+    return (color: string) => {
+      const cached = colorCache.get(color);
+      if (cached) return cached;
+
+      const resolvedColor = getVisibleTraceColor(color, true);
+      colorCache.set(color, resolvedColor);
+      return resolvedColor;
+    };
+  })();
 
   // Build Plotly traces from function expressions
   const traces: Plotly.Data[] = [];
@@ -110,7 +123,7 @@ export async function renderGraphToSvg(
         axis.xMin,
         axis.xMax
       );
-      const visibleColor = getVisibleTraceColor(fn.color, isDarkBackground);
+      const visibleColor = resolveVisibleTraceColor(fn.color);
       traces.push({
         x,
         y,
@@ -126,7 +139,7 @@ export async function renderGraphToSvg(
 
   // Build Plotly traces from data traces
   for (const dt of dataTraces) {
-    const visibleColor = getVisibleTraceColor(dt.color, isDarkBackground);
+    const visibleColor = resolveVisibleTraceColor(dt.color);
     traces.push({
       x: dt.xValues,
       y: dt.yValues,

--- a/packages/core/src/ui/GraphPanel.tsx
+++ b/packages/core/src/ui/GraphPanel.tsx
@@ -6,7 +6,7 @@
  * Embedded inside the ExcaliMath sidebar.
  */
 
-import { useState, useCallback, useEffect, useRef, useMemo } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { validateExpression } from "../plugins/graph/evaluator";
 import { renderGraphToSvg, parseCsvData } from "../plugins/graph/plotRenderer";
 import { plotTemplates } from "../plugins/graph/templates";
@@ -45,7 +45,6 @@ export function GraphPanel({
   const [previewSvg, setPreviewSvg] = useState("");
   const [rendering, setRendering] = useState(false);
   const [renderError, setRenderError] = useState("");
-  const previewRef = useRef<HTMLDivElement>(null);
   const t = useMemo(() => getTheme(isDark), [isDark]);
 
   useEffect(() => {
@@ -82,7 +81,10 @@ export function GraphPanel({
       try {
         setRendering(true);
         setRenderError("");
-        const result = await renderGraphToSvg(config);
+        const result = await renderGraphToSvg(config, {
+          isDark,
+          purpose: "preview",
+        });
         setPreviewSvg(result.svg);
       } catch (err) {
         setRenderError(err instanceof Error ? err.message : "Render failed");
@@ -92,7 +94,7 @@ export function GraphPanel({
       }
     }, 400);
     return () => clearTimeout(timeout);
-  }, [config]);
+  }, [config, isDark]);
 
   const updateFunction = useCallback((index: number, updates: Partial<FunctionTrace>) => {
     setConfig((prev) => ({
@@ -168,14 +170,17 @@ export function GraphPanel({
   const handleInsert = useCallback(async () => {
     try {
       setRendering(true);
-      const result = await renderGraphToSvg(config);
+      const result = await renderGraphToSvg(config, {
+        isDark,
+        purpose: "insert",
+      });
       onInsert(config, result.svg, result.width, result.height);
     } catch (err) {
       setRenderError(err instanceof Error ? err.message : "Failed to render graph");
     } finally {
       setRendering(false);
     }
-  }, [config, onInsert]);
+  }, [config, onInsert, isDark]);
 
   const hasValidContent =
     config.functions.some((fn, i) => fn.expression.trim() && !errors[i]) ||
@@ -392,7 +397,6 @@ export function GraphPanel({
           <div style={{ display: "flex", flexDirection: "column", gap: 6, marginTop: 6, width: "100%" }}>
             <label style={labelStyle}>Preview</label>
             <div
-              ref={previewRef}
               style={{
                 backgroundColor: t.bgElevated, borderRadius: 6,
                 border: `1px solid ${t.borderLight}`, overflowX: "auto", overflowY: "hidden",


### PR DESCRIPTION
## Summary
This PR improves graph readability in dark themes while keeping rendering fast and implementation complexity low.

## Changes
- Adds theme-aware palette selection for graph rendering, including transparent background preview behavior.
- Updates axis, grid, legend, and font colors to maintain contrast on dark backgrounds.
- Passes render intent from the panel: preview uses UI theme context, insert keeps output behavior consistent.
- Removes an unused preview ref in the graph panel.
-  Introduces a small per-render color cache in the renderer to avoid repeated hex parsing/luminance checks for repeated trace colors.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation update
- [ ] New shape library / shapes

## Checklist
- [x] `npm run build` passes
- [x] Code follows existing style conventions
- [ ] Exported functions/interfaces have JSDoc comments
- [x] Self-reviewed the diff
