### PR TITLE
Remove .excalidrawlib import from ExcaliMath, add canvas text measurement

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,3 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     versioning-strategy: increase
-    groups:
-      all-deps:
-        patterns:
-          - "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1300,9 +1300,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1320,9 +1317,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1340,9 +1334,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1360,9 +1351,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1380,9 +1368,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1400,9 +1385,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3957,9 +3939,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
       "funding": [
         {
           "type": "github",
@@ -3968,10 +3950,10 @@
       ],
       "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/normalize-path": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,6 @@
   },
   "overrides": {
     "lodash-es": "^4.18.0",
-    "nanoid": "^3.3.8"
+    "nanoid": "^5.1.6"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,6 @@ export {
 export {
   builtInPacks,
   shapeToExcalidrawElements,
-  parseExcalidrawLib,
   searchShapes,
 } from "./plugins/geometry";
 export { LibraryPanel } from "./ui/LibraryPanel";

--- a/src/plugins/geometry/index.ts
+++ b/src/plugins/geometry/index.ts
@@ -1,7 +1,6 @@
 export {
   builtInPacks,
   shapeToExcalidrawElements,
-  parseExcalidrawLib,
   searchShapes,
 } from "./registry";
 export type { ShapeInsertResult } from "./registry";

--- a/src/plugins/geometry/registry.ts
+++ b/src/plugins/geometry/registry.ts
@@ -5,10 +5,11 @@
  * LibraryShape definitions into Excalidraw-ready elements (both native
  * elements and SVG image elements for shapes with smooth curves).
  *
- * Also provides .excalidrawlib file import and cross-pack search.
+ * Also provides cross-pack search.
  */
 
 import type { LibraryPack, LibraryShape, ExcalidrawLibElement } from "./types";
+import { FONT_FAMILY } from "@excalidraw/excalidraw";
 import { svgToDataUrl, createFileEntry } from "../../core/elementFactory";
 import { geometryShapes } from "./packs/geometry";
 import { algebraShapes } from "./packs/algebra";
@@ -62,6 +63,75 @@ export const builtInPacks: LibraryPack[] = [
     enabled: true,
   },
 ];
+
+/** Measure text width and height using offscreen canvas (matching Excalidraw's approach) */
+let canvas: HTMLCanvasElement | null = null;
+function getCanvasContext(): CanvasRenderingContext2D {
+  if (!canvas) {
+    canvas = document.createElement("canvas");
+  }
+  return canvas.getContext("2d")!;
+}
+
+/** Font-family names + fallback chains, matching Excalidraw's internal getFontFamilyString */
+const FONT_FAMILY_NAMES: Record<number, string> = {
+  [FONT_FAMILY.Virgil]: "Virgil, Segoe UI Emoji",
+  [FONT_FAMILY.Helvetica]: "Helvetica, Segoe UI Emoji",
+  [FONT_FAMILY.Cascadia]: "Cascadia, Segoe UI Emoji",
+  [FONT_FAMILY.Excalifont]: "Excalifont, Xiaolai, Segoe UI Emoji",
+  [FONT_FAMILY.Nunito]: "Nunito, Segoe UI Emoji",
+  [FONT_FAMILY["Lilita One"]]: "Lilita One, Segoe UI Emoji",
+  [FONT_FAMILY["Comic Shanns"]]: "Comic Shanns, Segoe UI Emoji",
+  [FONT_FAMILY["Liberation Sans"]]: "Liberation Sans, Segoe UI Emoji",
+};
+
+function getFontString(fontSize: number, fontFamily: number): string {
+  const name = FONT_FAMILY_NAMES[fontFamily] || FONT_FAMILY_NAMES[FONT_FAMILY.Virgil];
+  return `${fontSize}px ${name}`;
+}
+
+/** Per-family line heights, matching Excalidraw's internal FONT_METADATA */
+const LINE_HEIGHTS: Record<number, number> = {
+  [FONT_FAMILY.Virgil]: 1.25,
+  [FONT_FAMILY.Helvetica]: 1.15,
+  [FONT_FAMILY.Cascadia]: 1.2,
+  [FONT_FAMILY.Excalifont]: 1.25,
+  [FONT_FAMILY.Nunito]: 1.35,
+  [FONT_FAMILY["Lilita One"]]: 1.15,
+  [FONT_FAMILY["Comic Shanns"]]: 1.25,
+  [FONT_FAMILY["Liberation Sans"]]: 1.15,
+};
+
+function measureText(text: string, fontSize: number, fontFamily: number): { width: number; height: number } {
+  const lineHeight = LINE_HEIGHTS[fontFamily] || 1.25;
+  const height = fontSize * lineHeight * text.split("\n").length;
+  if (text.trim() === "") {
+    return { width: 0, height };
+  }
+  const ctx = getCanvasContext();
+  ctx.font = getFontString(fontSize, fontFamily);
+  const lines = text.split("\n");
+  let maxWidth = 0;
+  for (const line of lines) {
+    maxWidth = Math.max(maxWidth, ctx.measureText(line || " ").width);
+  }
+  return { width: maxWidth, height };
+}
+
+/** Compute x offset for text alignment so the text appears at the intended position */
+function getTextAlignOffset(
+  textAlign: string | undefined,
+  definedWidth: number,
+  measuredWidth: number,
+): number {
+  if (textAlign === "center") {
+    return (definedWidth - measuredWidth) / 2;
+  }
+  if (textAlign === "right") {
+    return definedWidth - measuredWidth;
+  }
+  return 0;
+}
 
 /** Generate a random Excalidraw element ID */
 function generateId(): string {
@@ -161,17 +231,26 @@ export function shapeToExcalidrawElements(
     };
 
     if (el.type === "text") {
+      const fontSize = el.fontSize || 16;
+      const fontFamily = el.fontFamily || 1;
+      const text = el.text || "";
+      const measured = measureText(text, fontSize, fontFamily);
+      const alignOffsetX = getTextAlignOffset(el.textAlign, el.width > 0 ? el.width : measured.width, measured.width);
+
       return {
         ...base,
-        text: el.text || "",
-        fontSize: el.fontSize || 16,
-        fontFamily: el.fontFamily || 1,
+        x: base.x + alignOffsetX,
+        width: measured.width,
+        height: measured.height,
+        text,
+        fontSize,
+        fontFamily,
         textAlign: el.textAlign || "left",
         verticalAlign: "top",
         containerId: null,
-        originalText: el.text || "",
+        originalText: text,
         autoResize: true,
-        lineHeight: 1.25,
+        lineHeight: LINE_HEIGHTS[fontFamily] || 1.25,
       };
     }
 
@@ -191,32 +270,6 @@ export function shapeToExcalidrawElements(
   });
 
   return { elements, files: [] };
-}
-
-/**
- * Parse an .excalidrawlib JSON file and return a LibraryPack.
- */
-export function parseExcalidrawLib(json: string, name: string): LibraryPack {
-  const parsed = JSON.parse(json);
-  if (parsed.type !== "excalidrawlib") {
-    throw new Error("Invalid file: not an excalidrawlib file");
-  }
-
-  const libraryItems = parsed.libraryItems || parsed.library || [];
-  const shapes: LibraryShape[] = libraryItems.map(
-    (item: { name?: string; elements: ExcalidrawLibElement[] }, i: number) => ({
-      name: item.name || `Shape ${i + 1}`,
-      elements: item.elements || [],
-    })
-  );
-
-  return {
-    name,
-    description: `Imported library: ${name}`,
-    gradeRange: "Custom",
-    shapes,
-    enabled: true,
-  };
 }
 
 /** Filter shapes across enabled packs by search term */

--- a/src/ui/LibraryPanel.tsx
+++ b/src/ui/LibraryPanel.tsx
@@ -1,15 +1,15 @@
 /**
  * @module LibraryPanel
  *
- * Shape library browser with search, pack filtering, toggle controls,
- * and custom .excalidrawlib import. Embedded inside the ExcaliMath sidebar.
+ * Shape library browser with search, pack filtering, and toggle controls.
+ * Embedded inside the ExcaliMath sidebar. .excalidrawlib imports are handled
+ * by Excalidraw's native library, not here.
  */
 
-import { useState, useCallback, useMemo, useRef } from "react";
+import { useState, useCallback, useMemo } from "react";
 import {
   builtInPacks,
   searchShapes,
-  parseExcalidrawLib,
   type LibraryPack,
   type LibraryShape,
 } from "../plugins/geometry";
@@ -29,7 +29,6 @@ export function LibraryPanel({ onInsert, onClose, visible, isDark = false }: Lib
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedPack, setSelectedPack] = useState("");
   const [showToggles, setShowToggles] = useState(false);
-  const fileInputRef = useRef<HTMLInputElement>(null);
   const t = useMemo(() => getTheme(isDark), [isDark]);
 
   const togglePack = useCallback((packName: string) => {
@@ -52,23 +51,6 @@ export function LibraryPanel({ onInsert, onClose, visible, isDark = false }: Lib
     }
     return results;
   }, [packs, searchTerm, selectedPack]);
-
-  const handleImportFile = useCallback(
-    async (e: React.ChangeEvent<HTMLInputElement>) => {
-      const file = e.target.files?.[0];
-      if (!file) return;
-      try {
-        const text = await file.text();
-        const name = file.name.replace(/\.excalidrawlib$/, "");
-        const imported = parseExcalidrawLib(text, name);
-        setPacks((prev) => [...prev, imported]);
-        setSelectedPack(imported.name);
-      } catch (err) {
-        alert(`Failed to import: ${err instanceof Error ? err.message : "Unknown error"}`);
-      }
-      if (fileInputRef.current) fileInputRef.current.value = "";
-    }, []
-  );
 
   const totalShapes = packs.filter((p) => p.enabled).reduce((sum, p) => sum + p.shapes.length, 0);
 
@@ -173,18 +155,6 @@ export function LibraryPanel({ onInsert, onClose, visible, isDark = false }: Lib
             {searchTerm ? "No shapes match your search." : "No packs enabled."}
           </div>
         )}
-
-        {/* Import button — flows inside the grid */}
-        <div style={{ gridColumn: "1 / -1", marginTop: 4 }}>
-          <input ref={fileInputRef} type="file" accept=".excalidrawlib" onChange={handleImportFile} aria-label="Import library file" style={{ display: "none" }} />
-          <button type="button" onClick={() => fileInputRef.current?.click()}
-            style={{
-              width: "100%", padding: "8px 12px", border: `1px dashed ${t.border}`, borderRadius: 6,
-              background: "none", cursor: "pointer", fontSize: 12, color: t.accent, fontWeight: 500,
-            }}>
-            Import .excalidrawlib
-          </button>
-        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Removes the custom .excalidrawlib import handler (parseExcalidrawLib, import button, excalidrawAPI prop) from ExcaliMath's LibraryPanel — delegating library imports to Excalidraw's native library menu. Adds canvas-based text measurement for shape text elements, using Excalidraw's FONT_FAMILY names and per-family lineHeight values.